### PR TITLE
Fix crashes on Windows 10 < 1809 by making CreateDispatcherQueueController optional

### DIFF
--- a/windows/video_view_plugin.cpp
+++ b/windows/video_view_plugin.cpp
@@ -167,7 +167,7 @@ class VideoController : public enable_shared_from_this<VideoController> {
 				// Get the DispatcherQueue from the controller using WinRT wrapper
 				try {
 					// Create WinRT wrapper from ABI interface
-					winrt::Windows::System::DispatcherQueueController controller;
+					winrt::Windows::System::DispatcherQueueController controller{ nullptr };
 					winrt::copy_from_abi(controller, dispatcherController.Get());
 					dispatcherQueue = controller.DispatcherQueue();
 					OutputDebugStringW(L"VideoViewPlugin: DispatcherQueueController created successfully\n");


### PR DESCRIPTION
### Problem

The plugin was crashing on Windows 10 versions older than 1809 because it directly called CreateDispatcherQueueController() from CoreMessaging.dll. This function is not available in older Windows versions, causing a hard failure at runtime when the symbol is missing.